### PR TITLE
Allowing bucket policy creation to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-s3-module?ref=0.1.0
+github.com/pbs/terraform-aws-s3-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -28,7 +28,7 @@ Integrate this module like so:
 
 ```hcl
 module "s3" {
-  source = "github.com/pbs/terraform-aws-s3-module?ref=0.1.0"
+  source = "github.com/pbs/terraform-aws-s3-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -63,7 +63,7 @@ module "s3" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.1.0`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -127,6 +127,7 @@ No modules.
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
 | <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | Policy to apply to the bucket. If null, one will be guessed based on surrounding functionality | `string` | `null` | no |
 | <a name="input_cors_rules"></a> [cors\_rules](#input\_cors\_rules) | CORS Rules | <pre>set(object({<br>    allowed_headers = list(string),<br>    allowed_methods = list(string),<br>    allowed_origins = list(string),<br>    expose_headers  = list(string),<br>    max_age_seconds = number<br>  }))</pre> | `[]` | no |
+| <a name="input_create_bucket_policy"></a> [create\_bucket\_policy](#input\_create\_bucket\_policy) | Create a bucket policy for the bucket | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Allow destruction of an S3 bucket without clearing out the contents first | `bool` | `false` | no |
 | <a name="input_force_tls"></a> [force\_tls](#input\_force\_tls) | Deny HTTP requests that are made to the bucket without TLS. | `bool` | `true` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `true` | no |

--- a/examples/no-policy/.gitignore
+++ b/examples/no-policy/.gitignore
@@ -1,0 +1,2 @@
+backend.tf
+provider.tf

--- a/examples/no-policy/.terraform.lock.hcl
+++ b/examples/no-policy/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.5.0"
+  constraints = ">= 4.5.0"
+  hashes = [
+    "h1:6y12cTFaxpFv4qyU3gkV9M15eSBBrgInoKY1iaHuhvg=",
+    "zh:0573de96ba316d808be9f8d6fc8e8e68e0e6b614ed4d707bd236c4f7b46ac8b1",
+    "zh:37560469042f5f43fdb961eb6e6b0a8f95057df68af2c1168d5b8c66ddcb1512",
+    "zh:44bb4f6bc1f58e19b8bf7041f981a2549a351762d17dd39654eb24d1fa7991c7",
+    "zh:53af6557b68e547ac5c02cfd0e47ef63c8e9edfacf46921ccc97d73c0cd362c9",
+    "zh:578a583f69a8e5947d66b2b9d6969690043b6887f6b574263be7ef05f82a82ad",
+    "zh:6c2d42f30db198a4e7badd7f8037ef9bd951cfd6cf40328c6a7eed96801a374e",
+    "zh:758f3fc4d833dbdda57a4db743cbbddc8fd8c0492df47771b848447ba7876ce5",
+    "zh:78241bd45e2f6102055787b3697849fee7e9c28a744ba59cad956639c1aca07b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a3a7f4699c097c7b8364d05a5df9f3bd5d005fd5736c28ec5dc8f8c0ee340512",
+    "zh:bf875483bf2ad6cfb4029813328cdcd9ea40f50b9f1c265f4e742fe8cc456157",
+    "zh:f4722596e8b5f012013f87bf4d2b7d302c248a04a144de4563b3e3f754a30c51",
+  ]
+}

--- a/examples/no-policy/main.tf
+++ b/examples/no-policy/main.tf
@@ -1,0 +1,10 @@
+module "s3" {
+  source = "../.."
+
+  create_bucket_policy = false
+
+  organization = var.organization
+  environment  = var.environment
+  product      = var.product
+  repo         = var.repo
+}

--- a/examples/no-policy/outputs.tf
+++ b/examples/no-policy/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "Name of the bucket"
+  value       = module.s3.name
+}
+
+output "arn" {
+  description = "ARN of the bucket"
+  value       = module.s3.arn
+}

--- a/examples/no-policy/sample-backend.tf
+++ b/examples/no-policy/sample-backend.tf
@@ -1,0 +1,9 @@
+# terraform {
+#   backend "s3" {
+#     bucket         = "my-bucket-tfstate"
+#     key            = "example-terraform-aws-s3-no-policy"
+#     profile        = "my-profile"
+#     region         = "us-east-1"
+#     dynamodb_table = "terraform-lock"
+#   }
+# }

--- a/examples/no-policy/sample-provider.tf
+++ b/examples/no-policy/sample-provider.tf
@@ -1,0 +1,12 @@
+# provider "aws" {
+#   region  = "us-east-1"
+#   profile = "my-profile"
+#   default_tags {
+#     tags = {
+#       product      = var.product
+#       environment  = var.environment
+#       repo         = var.repo
+#       organization = var.organization
+#     }
+#   }
+# }

--- a/examples/no-policy/tags.tf
+++ b/examples/no-policy/tags.tf
@@ -1,0 +1,45 @@
+variable "environment" {
+  description = "Environment (sharedtools, dev, staging, prod)"
+  type        = string
+
+  default = "sharedtools"
+
+  validation {
+    condition     = contains(["sharedtools", "dev", "staging", "prod"], var.environment)
+    error_message = "The environment variable must be one of [sharedtools, dev, staging, prod]."
+  }
+}
+
+variable "product" {
+  description = "Tag used to group resources according to application"
+
+  default = "example-tf-s3-no-policy"
+
+  validation {
+    condition     = can(regex("[a-z\\-]+", var.product))
+    error_message = "The product variable violates approved regex."
+  }
+}
+
+variable "repo" {
+  description = "Tag used to point to the repo using this module"
+
+  default = "https://github.com/pbs/terraform-s3-module.git"
+
+  validation {
+    condition     = can(regex("(?:git|ssh|https?|git@[-\\w.]+):(\\/\\/)?(.*?)(\\.git)(\\/?|\\#[-\\d\\w._]+?)$", var.repo))
+    error_message = "The repo variable violates approved regex."
+  }
+}
+
+variable "organization" {
+  description = "Organization using this module. Used to prefix tags so that they are easily identified as being from your organization"
+  type        = string
+
+  default = "example"
+
+  validation {
+    condition     = can(regex("[a-z\\-]+", var.organization))
+    error_message = "The organization variable violates approved regex."
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -19,9 +19,7 @@ locals {
     }
   ])
 
-  generate_bucket_policy = var.bucket_policy == null && (var.allow_anonymous_vpce_access || local.create_replication_target_policy)
-
-  create_bucket_policy = var.bucket_policy != null || local.generate_bucket_policy
+  generate_bucket_policy = var.create_bucket_policy && var.bucket_policy == null && (var.allow_anonymous_vpce_access || local.create_replication_target_policy || var.force_tls)
 
   bucket_policy = var.bucket_policy != null ? var.bucket_policy : local.generate_bucket_policy ? data.aws_iam_policy_document.bucket_policy_doc[0].json : null
 

--- a/optional.tf
+++ b/optional.tf
@@ -129,6 +129,12 @@ variable "replication_source" {
   })
 }
 
+variable "create_bucket_policy" {
+  description = "Create a bucket policy for the bucket"
+  default     = true
+  type        = bool
+}
+
 variable "bucket_policy" {
   description = "Policy to apply to the bucket. If null, one will be guessed based on surrounding functionality"
   default     = null

--- a/security.tf
+++ b/security.tf
@@ -50,7 +50,7 @@ resource "aws_iam_role_policy" "replication_policy" {
 }
 
 data "aws_iam_policy_document" "bucket_policy_doc" {
-  count = local.create_bucket_policy ? 1 : 0
+  count = local.generate_bucket_policy ? 1 : 0
   dynamic "statement" {
     for_each = var.allow_anonymous_vpce_access ? [var.allow_anonymous_vpce_access] : []
     content {
@@ -134,7 +134,7 @@ data "aws_iam_policy_document" "bucket_policy_doc" {
 }
 
 resource "aws_s3_bucket_policy" "bucket_policy" {
-  count = local.create_bucket_policy ? 1 : 0
+  count = var.create_bucket_policy ? 1 : 0
 
   bucket = aws_s3_bucket.bucket.id
   policy = local.bucket_policy


### PR DESCRIPTION
This is important to add because creating the bucket and policy in the same module can cause problems with Terraform ordering and dependency issues.

