### PR TITLE
Switching to utilization of bucket policy module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-s3-module?ref=0.2.3
+github.com/pbs/terraform-aws-s3-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -28,7 +28,7 @@ Integrate this module like so:
 
 ```hcl
 module "s3" {
-  source = "github.com/pbs/terraform-aws-s3-module?ref=0.2.3"
+  source = "github.com/pbs/terraform-aws-s3-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -63,7 +63,7 @@ module "s3" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.2.3`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -90,7 +90,9 @@ Below is automatically generated documentation on this Terraform module using [t
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3_policy"></a> [s3\_policy](#module\_s3\_policy) | github.com/pbs/terraform-aws-s3-bucket-policy-module | 1.0.1 |
 
 ## Resources
 
@@ -111,7 +113,6 @@ No modules.
 | [aws_s3_bucket_versioning.versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_default_tags.common_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
-| [aws_iam_policy_document.bucket_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -123,10 +124,11 @@ No modules.
 | <a name="input_product"></a> [product](#input\_product) | Tag used to group resources according to product | `string` | n/a | yes |
 | <a name="input_repo"></a> [repo](#input\_repo) | Tag used to point to the repo using this module | `string` | n/a | yes |
 | <a name="input_acl"></a> [acl](#input\_acl) | Canned ACL for the bucket. If an ACL is not provided, the bucket will be created with ACLs disabled | `string` | `null` | no |
-| <a name="input_allow_anonymous_vpce_access"></a> [allow\_anonymous\_vpce\_access](#input\_allow\_anonymous\_vpce\_access) | Create bucket policy that allows anonymous VPCE access. If bucket\_policy is defined, this will be ignored. | `bool` | `false` | no |
+| <a name="input_allow_anonymous_vpce_access"></a> [allow\_anonymous\_vpce\_access](#input\_allow\_anonymous\_vpce\_access) | Create bucket policy that allows anonymous VPCE access. | `bool` | `false` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
-| <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | Policy to apply to the bucket. If null, one will be guessed based on surrounding functionality | `string` | `null` | no |
+| <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | Policy to apply to the bucket. If null, one will be guessed based on other variables. | `string` | `null` | no |
+| <a name="input_cloudfront_oac_access_statements"></a> [cloudfront\_oac\_access\_statements](#input\_cloudfront\_oac\_access\_statements) | List of objects that define the CloudFront origin access identity access statement. Each object must have a `cloudfront_arn` and `path` key. | <pre>list(object({<br>    cloudfront_arn = string<br>    path           = optional(string, "*")<br>  }))</pre> | `[]` | no |
 | <a name="input_cors_rules"></a> [cors\_rules](#input\_cors\_rules) | CORS Rules | <pre>set(object({<br>    allowed_headers = list(string),<br>    allowed_methods = list(string),<br>    allowed_origins = list(string),<br>    expose_headers  = list(string),<br>    max_age_seconds = number<br>  }))</pre> | `[]` | no |
 | <a name="input_create_bucket_policy"></a> [create\_bucket\_policy](#input\_create\_bucket\_policy) | Create a bucket policy for the bucket | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Allow destruction of an S3 bucket without clearing out the contents first | `bool` | `false` | no |
@@ -138,10 +140,12 @@ No modules.
 | <a name="input_is_versioned"></a> [is\_versioned](#input\_is\_versioned) | Is versioning enabled? | `bool` | `true` | no |
 | <a name="input_lifecycle_rules"></a> [lifecycle\_rules](#input\_lifecycle\_rules) | List of maps containing configuration of object lifecycle management. | `any` | <pre>[<br>  {<br>    "abort_incomplete_multipart_upload_days": 7,<br>    "enabled": true,<br>    "id": "default-lifecycle-rule",<br>    "noncurrent_version_transition": [<br>      {<br>        "days": 30,<br>        "storage_class": "GLACIER"<br>      }<br>    ],<br>    "transition": [<br>      {<br>        "days": 7,<br>        "storage_class": "INTELLIGENT_TIERING"<br>      }<br>    ]<br>  }<br>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to use for the bucket. If null, will default to product. | `string` | `null` | no |
+| <a name="input_override_policy_documents"></a> [override\_policy\_documents](#input\_override\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank sids will override statements with the same sid from earlier documents in the list. Statements with non-blank sids will also override statements with the same sid from documents provided in the source\_json and source\_policy\_documents arguments. Non-overriding statements will be added to the exported document. | `list(string)` | `null` | no |
 | <a name="input_replication_configuration_set"></a> [replication\_configuration\_set](#input\_replication\_configuration\_set) | Set of (single) replication that needs to be managed by this bucket. If empty, no replication takes place. | <pre>set(object({<br>    role = string,<br>    rules = set(object({<br>      id                                           = string<br>      priority                                     = number<br>      status                                       = string<br>      destination_account_id                       = string<br>      destination_bucket                           = string<br>      destination_access_control_translation_owner = string<br>    }))<br>  }))</pre> | `[]` | no |
 | <a name="input_replication_configuration_shortcut"></a> [replication\_configuration\_shortcut](#input\_replication\_configuration\_shortcut) | Shorthand version of the configuration used in replication\_configuration\_set. Is overridden by replication\_configuration\_set if defined. | <pre>object({<br>    destination_account_id = string<br>    destination_bucket     = string<br>  })</pre> | `null` | no |
-| <a name="input_replication_source"></a> [replication\_source](#input\_replication\_source) | The account number and role for the source bucket in a replication configuration. Creates a bucket policy. | <pre>object({<br>    account_id = string<br>    role       = string<br>  })</pre> | `null` | no |
+| <a name="input_replication_source"></a> [replication\_source](#input\_replication\_source) | The account number and role for the source bucket in a replication configuration. | <pre>object({<br>    account_id = string<br>    role       = string<br>  })</pre> | `null` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `true` | no |
+| <a name="input_source_policy_documents"></a> [source\_policy\_documents](#input\_source\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. Statements defined in source\_policy\_documents or source\_json must have unique sids. Statements with the same sid from documents assigned to the override\_json and override\_policy\_documents arguments will override source statements. | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Extra tags | `map(string)` | `{}` | no |
 | <a name="input_use_prefix"></a> [use\_prefix](#input\_use\_prefix) | Create bucket with prefix instead of explicit name | `bool` | `true` | no |
 | <a name="input_vpce"></a> [vpce](#input\_vpce) | Name of the VPC endpoint that should have access to this bucket. Only used when `allow_anonymous_vpce_access` is true. | `string` | `null` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -21,7 +21,7 @@ locals {
 
   generate_bucket_policy = var.create_bucket_policy && var.bucket_policy == null && (var.allow_anonymous_vpce_access || local.create_replication_target_policy || var.force_tls)
 
-  bucket_policy = var.bucket_policy != null ? var.bucket_policy : local.generate_bucket_policy ? data.aws_iam_policy_document.bucket_policy_doc[0].json : null
+  bucket_policy = var.bucket_policy != null ? var.bucket_policy : local.generate_bucket_policy ? module.s3_policy[0].bucket_policy : null
 
   create_replication_target_policy = var.replication_source != null
   destination_bucket               = length(local.replication_configuration_set) == 0 ? null : tolist(tolist(local.replication_configuration_set)[0].rules)[0].destination_bucket

--- a/optional-policy.tf
+++ b/optional-policy.tf
@@ -1,0 +1,53 @@
+variable "bucket_policy" {
+  description = "Policy to apply to the bucket. If null, one will be guessed based on other variables."
+  default     = null
+  type        = string
+}
+
+variable "force_tls" {
+  description = "Deny HTTP requests that are made to the bucket without TLS."
+  default     = true
+  type        = bool
+}
+
+variable "replication_source" {
+  description = "The account number and role for the source bucket in a replication configuration."
+  default     = null
+  type = object({
+    account_id = string
+    role       = string
+  })
+}
+
+variable "allow_anonymous_vpce_access" {
+  description = "Create bucket policy that allows anonymous VPCE access."
+  default     = false
+  type        = bool
+}
+
+variable "vpce" {
+  description = "Name of the VPC endpoint that should have access to this bucket. Only used when `allow_anonymous_vpce_access` is true."
+  default     = null
+  type        = string
+}
+
+variable "source_policy_documents" {
+  description = "List of IAM policy documents that are merged together into the exported document. Statements defined in source_policy_documents or source_json must have unique sids. Statements with the same sid from documents assigned to the override_json and override_policy_documents arguments will override source statements."
+  default     = null
+  type        = list(string)
+}
+
+variable "override_policy_documents" {
+  description = "List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank sids will override statements with the same sid from earlier documents in the list. Statements with non-blank sids will also override statements with the same sid from documents provided in the source_json and source_policy_documents arguments. Non-overriding statements will be added to the exported document."
+  default     = null
+  type        = list(string)
+}
+
+variable "cloudfront_oac_access_statements" {
+  description = "List of objects that define the CloudFront origin access identity access statement. Each object must have a `cloudfront_arn` and `path` key."
+  default     = []
+  type = list(object({
+    cloudfront_arn = string
+    path           = optional(string, "*")
+  }))
+}

--- a/optional.tf
+++ b/optional.tf
@@ -120,37 +120,10 @@ variable "replication_configuration_shortcut" {
   })
 }
 
-variable "replication_source" {
-  description = "The account number and role for the source bucket in a replication configuration. Creates a bucket policy."
-  default     = null
-  type = object({
-    account_id = string
-    role       = string
-  })
-}
-
 variable "create_bucket_policy" {
   description = "Create a bucket policy for the bucket"
   default     = true
   type        = bool
-}
-
-variable "bucket_policy" {
-  description = "Policy to apply to the bucket. If null, one will be guessed based on surrounding functionality"
-  default     = null
-  type        = string
-}
-
-variable "allow_anonymous_vpce_access" {
-  description = "Create bucket policy that allows anonymous VPCE access. If bucket_policy is defined, this will be ignored."
-  default     = false
-  type        = bool
-}
-
-variable "vpce" {
-  description = "Name of the VPC endpoint that should have access to this bucket. Only used when `allow_anonymous_vpce_access` is true."
-  default     = null
-  type        = string
 }
 
 variable "inventory_bucket" {
@@ -191,12 +164,6 @@ variable "ignore_public_acls" {
 
 variable "restrict_public_buckets" {
   description = "Whether Amazon S3 should restrict public bucket policies for this bucket."
-  default     = true
-  type        = bool
-}
-
-variable "force_tls" {
-  description = "Deny HTTP requests that are made to the bucket without TLS."
   default     = true
   type        = bool
 }


### PR DESCRIPTION
This is a breaking change due to an address update on the bucket policy.

To mitigate the impact of this breaking change, move the Terraform state of the bucket policy with something like the following:

```bash
terraform state mv 'aws_s3_bucket_policy.bucket_policy[0]' 'module.s3_policy.aws_s3_bucket_policy.bucket_policy[0]' 
```