### PR TITLE
Improving ACL control

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-s3-module?ref=3.0.9
+github.com/pbs/terraform-aws-s3-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -28,7 +28,7 @@ Integrate this module like so:
 
 ```hcl
 module "s3" {
-  source = "github.com/pbs/terraform-aws-s3-module?ref=3.0.9"
+  source = "github.com/pbs/terraform-aws-s3-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -63,7 +63,7 @@ module "s3" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`3.0.9`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -122,7 +122,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_organization"></a> [organization](#input\_organization) | Organization using this module. Used to prefix tags so that they are easily identified as being from your organization | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | Tag used to group resources according to product | `string` | n/a | yes |
 | <a name="input_repo"></a> [repo](#input\_repo) | Tag used to point to the repo using this module | `string` | n/a | yes |
-| <a name="input_acl"></a> [acl](#input\_acl) | Canned ACL for the bucket. If an ACL is not provided, the bucket will be created with ACLs disabled | `string` | `null` | no |
+| <a name="input_acl"></a> [acl](#input\_acl) | ACL configuration for the bucket. If an ACL is not provided, the bucket will be created with ACLs disabled | <pre>object({<br>    canned_acl            = optional(string)<br>    expected_bucket_owner = optional(string)<br>    access_control_policy = optional(object({<br>      grants = set(object({<br>        grantee = object({<br>          type          = string<br>          email_address = optional(string)<br>          id            = optional(string)<br>          uri           = optional(string)<br>        })<br>        permission = string<br>      }))<br>      owner = object({<br>        id           = string<br>        display_name = optional(string)<br>      })<br>    }))<br>  })</pre> | `null` | no |
 | <a name="input_allow_anonymous_vpce_access"></a> [allow\_anonymous\_vpce\_access](#input\_allow\_anonymous\_vpce\_access) | Create bucket policy that allows anonymous VPCE access. | `bool` | `false` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |

--- a/examples/acl/.gitignore
+++ b/examples/acl/.gitignore
@@ -1,0 +1,2 @@
+backend.tf
+provider.tf

--- a/examples/acl/.terraform.lock.hcl
+++ b/examples/acl/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.62.0"
+  constraints = ">= 4.5.0"
+  hashes = [
+    "h1:H/nY2teFoN9LU+Xtc1dx7TGS6w2HrARs0Q7cFb6vbus=",
+    "zh:12059dc2b639797b9facb6397ac6aec563891634be8e5aadf3a457590c1147d4",
+    "zh:1b3515d70b6998359d0a6d3b3c287940ab2e5c59cd02f95c7d9dab7df76e86b6",
+    "zh:423a1d3afdb6b625f2e3b06770ef4324740d400ff1a0d6d566c87d3f841d74fc",
+    "zh:58612b5a27d929dd1dff04d18d840b9cc59d45fed06247f0c2f87c1e5d3257d9",
+    "zh:5b243cd2250dd097293e06c1cc85e805565194e53f594ccd070252c7af644f54",
+    "zh:61ad9739e7d6fca8fddef269cb2ba7285f0632f5f27660755662550e1f69e4bb",
+    "zh:6700d86f5bfcae8491c87a7769b211a079dbf6dfb325bde76bf407aca3e76ff4",
+    "zh:67c7925f3b7ac1988c2aee8965b1f6f04738984cf8ae302b88215549793d14c1",
+    "zh:686770264b907b3e4c75fd751f8ea717a7e393d2fbde0950c4703fa809e573f0",
+    "zh:740236fda351a8f4976ddbd37e543c8d746a409e3a6aa290a8c5ff774b264455",
+    "zh:88ace13281a344044624ed088125c30f1a803188bf95874d09ca7e95725d5727",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a4810a034f5def017607b0b079c7867c983da653928bd9f67edbc18575c0b629",
+    "zh:e1c10e1641b5f17fec61910d6c3514e241f650ced84523f09cb16271a9a1e651",
+    "zh:f63593ee2e01a2e1096ae9959fa43f0521114b3335f6440170f0d35d1969e8a2",
+  ]
+}

--- a/examples/acl/main.tf
+++ b/examples/acl/main.tf
@@ -1,0 +1,12 @@
+module "s3" {
+  source = "../.."
+
+  acl = {
+    canned_acl = "private"
+  }
+
+  organization = var.organization
+  environment  = var.environment
+  product      = var.product
+  repo         = var.repo
+}

--- a/examples/acl/outputs.tf
+++ b/examples/acl/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "Name of the bucket"
+  value       = module.s3.name
+}
+
+output "arn" {
+  description = "ARN of the bucket"
+  value       = module.s3.arn
+}

--- a/examples/acl/sample-backend.tf
+++ b/examples/acl/sample-backend.tf
@@ -1,0 +1,9 @@
+# terraform {
+#   backend "s3" {
+#     bucket         = "my-bucket-tfstate"
+#     key            = "example-terraform-aws-s3-acl"
+#     profile        = "my-profile"
+#     region         = "us-east-1"
+#     dynamodb_table = "terraform-lock"
+#   }
+# }

--- a/examples/acl/sample-provider.tf
+++ b/examples/acl/sample-provider.tf
@@ -1,0 +1,12 @@
+# provider "aws" {
+#   region  = "us-east-1"
+#   profile = "my-profile"
+#   default_tags {
+#     tags = {
+#       product      = var.product
+#       environment  = var.environment
+#       repo         = var.repo
+#       organization = var.organization
+#     }
+#   }
+# }

--- a/examples/acl/tags.tf
+++ b/examples/acl/tags.tf
@@ -1,0 +1,45 @@
+variable "environment" {
+  description = "Environment (sharedtools, dev, staging, prod)"
+  type        = string
+
+  default = "sharedtools"
+
+  validation {
+    condition     = contains(["sharedtools", "dev", "staging", "prod"], var.environment)
+    error_message = "The environment variable must be one of [sharedtools, dev, staging, prod]."
+  }
+}
+
+variable "product" {
+  description = "Tag used to group resources according to application"
+
+  default = "example-tf-s3-acl"
+
+  validation {
+    condition     = can(regex("[a-z\\-]+", var.product))
+    error_message = "The product variable violates approved regex."
+  }
+}
+
+variable "repo" {
+  description = "Tag used to point to the repo using this module"
+
+  default = "https://github.com/pbs/terraform-s3-module.git"
+
+  validation {
+    condition     = can(regex("(?:git|ssh|https?|git@[-\\w.]+):(\\/\\/)?(.*?)(\\.git)(\\/?|\\#[-\\d\\w._]+?)$", var.repo))
+    error_message = "The repo variable violates approved regex."
+  }
+}
+
+variable "organization" {
+  description = "Organization using this module. Used to prefix tags so that they are easily identified as being from your organization"
+  type        = string
+
+  default = "example"
+
+  validation {
+    condition     = can(regex("[a-z\\-]+", var.organization))
+    error_message = "The organization variable violates approved regex."
+  }
+}

--- a/optional.tf
+++ b/optional.tf
@@ -17,9 +17,31 @@ variable "is_versioned" {
 }
 
 variable "acl" {
-  description = "Canned ACL for the bucket. If an ACL is not provided, the bucket will be created with ACLs disabled"
+  description = "ACL configuration for the bucket. If an ACL is not provided, the bucket will be created with ACLs disabled"
   default     = null
-  type        = string
+  type = object({
+    canned_acl            = optional(string)
+    expected_bucket_owner = optional(string)
+    access_control_policy = optional(object({
+      grants = set(object({
+        grantee = object({
+          type          = string
+          email_address = optional(string)
+          id            = optional(string)
+          uri           = optional(string)
+        })
+        permission = string
+      }))
+      owner = object({
+        id           = string
+        display_name = optional(string)
+      })
+    }))
+  })
+  validation {
+    condition     = var.acl == null || !(try(var.acl.canned_acl, null) != null && try(var.acl.access_control_policy, null) != null)
+    error_message = "Only one of canned_acl or access_control_policy can be set"
+  }
 }
 
 variable "force_destroy" {

--- a/tests/acl_test.go
+++ b/tests/acl_test.go
@@ -1,0 +1,9 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestACLExample(t *testing.T) {
+	testS3(t, "acl")
+}


### PR DESCRIPTION
This is a breaking change, as it alters the type of the `acl` input.

This is required to grant full control over ACLs in buckets, rather than only supporting canned ACLs.