### PR TITLE
Update provider and tf versions to something sane

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.24.0"
   constraints = ">= 4.5.0"
   hashes = [
+    "h1:5kF6+4jUPI73O/uDvm/8/NiKRhiaOqMTqdo5l8uAygo=",
     "h1:tAteY6hnPFlxGx88cjNXQT3x5Of6lz0EUaZTn3wsjUA=",
     "zh:164b4ac71c9fc6b991021dd6e829591b0c1a0ebfb5831da0a7eb4f10f92c76a7",
     "zh:22e85772a1767498796f160b54a156db8173c4e238469dad8328a65093e033e1",

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-terraform      1.4.5
+terraform      1.9.0
 golang         1.20.3
 ripgrep        13.0.0
 tflint         0.46.0

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Below is automatically generated documentation on this Terraform module using [t
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_policy"></a> [s3\_policy](#module\_s3\_policy) | github.com/pbs/terraform-aws-s3-bucket-policy-module | 1.0.21 |
+| <a name="module_s3_policy"></a> [s3\_policy](#module\_s3\_policy) | github.com/pbs/terraform-aws-s3-bucket-policy-module | 1.0.24 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-s3-module?ref=4.0.14
+github.com/pbs/terraform-aws-s3-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -28,7 +28,7 @@ Integrate this module like so:
 
 ```hcl
 module "s3" {
-  source = "github.com/pbs/terraform-aws-s3-module?ref=4.0.14"
+  source = "github.com/pbs/terraform-aws-s3-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -63,7 +63,7 @@ module "s3" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`4.0.14`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -79,8 +79,8 @@ Below is automatically generated documentation on this Terraform module using [t
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 

--- a/security.tf
+++ b/security.tf
@@ -50,7 +50,7 @@ resource "aws_iam_role_policy" "replication_policy" {
 }
 
 module "s3_policy" {
-  source = "github.com/pbs/terraform-aws-s3-bucket-policy-module?ref=1.0.21"
+  source = "github.com/pbs/terraform-aws-s3-bucket-policy-module?ref=1.0.24"
   count  = var.create_bucket_policy ? 1 : 0
 
   name = aws_s3_bucket.bucket.id

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.9.0"
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     aws = {
-      version = ">= 4.5.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
Tested creation of a bucket with the following:

```
module "test_upgrade" {
  source = "github.com/pbs/terraform-aws-s3-module?ref=update-tf-and-provider"
  organization = "pbs-testing"
  environment  = "dev"
  product      = "noprod"
  repo         = "git@github.com:pbs/terraform-pbsorg.git"
}
```
```
[2025-01-07 11:28:25]» tf -v 
Terraform v1.9.8
on linux_amd64
+ provider registry.terraform.io/hashicorp/aws v5.49.0
```


