### PR TITLE
Lower tf + fix policy bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "encryption" {
   bucket = aws_s3_bucket.bucket.id
 
   rule {
+    blocked_encryption_types = [
+      "NONE"
+    ]
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }

--- a/security.tf
+++ b/security.tf
@@ -50,7 +50,7 @@ resource "aws_iam_role_policy" "replication_policy" {
 }
 
 module "s3_policy" {
-  source = "github.com/pbs/terraform-aws-s3-bucket-policy-module?ref=2.0.0"
+  source = "github.com/pbs-sdo/terraform-aws-s3-bucket-policy-module?ref=30566a7d8be3e870d99e5439be2d44001d55692e"
   count  = var.create_bucket_policy ? 1 : 0
 
   name = aws_s3_bucket.bucket.id

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.13.0"
+  required_version = ">= 1.11.6"
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     aws = {


### PR DESCRIPTION
Lowering required tf version so we can use opentofu (latest release is 1.11.6).

When applying changes, the `aws_s3_bucket_server_side_encryption_configuration` would not "stick" changes properly. That is, once applied, running `plan` will still show changes present. This is probably due to changes in the aws version; setting `blocked_encryption_types` explicitly fixes this.